### PR TITLE
Fix API#75 https://github.com/curt-labs/API/issues/75

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,18 @@ Philoshopy
 
 Local Development
 -
-Directions for setting up a local development environment can be found in [DEVELOPER.md](https://github.com/curt-labs/API/blob/master/DEVELOPER.md).
+Directions for setting up a local development environment can be found in [DEVELOPER.md](https://github.com/curt-labs/API/blob/goapi/DEVELOPER.md).
+
+Testing
+-
+The project uses [GoConvey](https://github.com/smartystreets/goconvey) as a testing framework. Follow the install directions from the GitHub repo and make sure you have`$GOPATH/bin` in your `$PATH`. Then go to the directory you want to test and run `goconvey`
+
+*Example*
+
+```
+~/workspace/gocode/src/github.com/curt-labs/API $ cd models/products/
+~/workspace/gocode/src/github.com/curt-labs/API/models/products $ goconvey
+```
 
 Deployment
 -

--- a/models/products/luverne_test.go
+++ b/models/products/luverne_test.go
@@ -526,7 +526,7 @@ func TestGetLuverneStyles(t *testing.T) {
 			ctx.Session, err = mgo.DialWithInfo(database.MongoPartConnectionString())
 			So(err, ShouldBeNil)
 
-			vals1, vals2, err := getLuverneStyles(ctx, "2016", "Ram", "Ram 1500", "")
+			vals1, vals2, err := getLuverneStyles(ctx, "2016", "Ram", "1500", "")
 			So(err, ShouldBeNil)
 			So(vals1, ShouldHaveSameTypeAs, []Part{})
 			So(vals2, ShouldHaveSameTypeAs, []LuverneLookupCategory{})
@@ -543,7 +543,7 @@ func TestGetLuverneStyles(t *testing.T) {
 			ctx.Session, err = mgo.DialWithInfo(database.MongoPartConnectionString())
 			So(err, ShouldBeNil)
 
-			vals1, vals2, err := getLuverneStyles(ctx, "2016", "Ram", "Ram 1500", "Aluminum Oval Bed Rails")
+			vals1, vals2, err := getLuverneStyles(ctx, "2016", "Ram", "1500", "Aluminum Oval Bed Rails")
 			So(err, ShouldBeNil)
 			So(vals1, ShouldHaveSameTypeAs, []Part{})
 			So(vals2, ShouldHaveSameTypeAs, []LuverneLookupCategory{})


### PR DESCRIPTION
In getLuverneModels() we were limiting our query select to the first element in an array, so not all valid models were included. No we return all elements of the array and filter out values that don't match the year and make when we create the return value.

Fixed luverne_test.go TestGetLuverneStyles test case where the model name no longer includes the make in the name. Was 'Ram 1500', now '1500'

Fixed README.md link to DEVELOPER.md
Added README.md Testing heading, it explains goconvey and gives a usage example.