### PR TITLE
Fixes #83 - Product Modified

### DIFF
--- a/controllers/part/part_ctlr.go
+++ b/controllers/part/part_ctlr.go
@@ -78,7 +78,7 @@ func All(w http.ResponseWriter, r *http.Request, params martini.Params, enc enco
 		}
 	}
 
-	parts, total, err := products.All(page, count, dtx)
+	parts, total, err := products.All(page, count, dtx, qs.Get("modified-from"), qs.Get("modified-to"))
 	if err != nil {
 		apierror.GenerateError("Trouble getting all parts", err, w, r)
 		return ""

--- a/controllers/part/part_test.go
+++ b/controllers/part/part_test.go
@@ -3,6 +3,11 @@ package part_ctlr
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/curt-labs/API/helpers/apicontextmock"
 	"github.com/curt-labs/API/helpers/database"
 	"github.com/curt-labs/API/helpers/testThatHttp"
@@ -12,10 +17,6 @@ import (
 	"github.com/curt-labs/API/models/products"
 	"github.com/curt-labs/API/models/video"
 	. "github.com/smartystreets/goconvey/convey"
-	"net/url"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func TestParts(t *testing.T) {
@@ -281,7 +282,10 @@ func TestParts(t *testing.T) {
 		So(testThatHttp.Response.Code, ShouldEqual, 200)
 		err = json.Unmarshal(testThatHttp.Response.Body.Bytes(), &parts)
 		So(err, ShouldBeNil)
-		So(parts, ShouldHaveSameTypeAs, []products.Part{})
+		So(parts, ShouldHyaveSameTypeAs, []products.Part{})
+
+		//TODO: test get all parts with format parameter
+		//TODO: test get all parts with modified param
 
 		//test get price
 		thyme = time.Now()

--- a/docs/Products.md
+++ b/docs/Products.md
@@ -1,7 +1,7 @@
 Parts
 ===
 List of endpoints
- 
+
  - [Get All Parts](#all-parts)
  - [Get Single Part](#single-part)
  - [Get Multiple Parts](#multi-parts)
@@ -12,24 +12,34 @@ Information about the part.
 
 *Example:*
 
-	http://goapi.curtmfg.com/part?key=[public api key]&count=20&page=2
-	
-	
+	http://goapi.curtmfg.com/part?key=[public api key]&count=20&page=2&modified-from=2017-01-02
+
+
 ####Parameters
 
 
-| Paramter  |  Description | 
+| Paramter  |  Description |
 |---|---|
 | key **(required)** | Provide your API key  |
 | count *(optional)* | The number of parts you want returned |
 | page *(optional)* | An offset multiplier based off the count |
+| format *(optional)* | The format you wish the data to be in (only supports `json-obj`) |
+| modified-from *(optional)* | Including this will only show products modified on or *after* this date |
+| modified-to *(optional)* | Including this will only show products modified on or *before* this date |
 
-####Response 
+####Response
 Returns an unnamed array of part objets. A part object is described in the Get Single Part response.
 
 | Property Name  |  Value |  Description |
 |---|---|---|
 |  | []object  | Array of part Objects  |
+
+If the **format** is selected to be `json-obj`, the response will be formatted differently, like so:
+
+| Property Name | Value | Description |
+|---|---|---|
+| items | []object | Array of part Objects |
+| count | integer | The total number of results |
 
 
 ##<a name="single-part"></a>Get Single Part `GET  - http://goapi.curtmfg.com/part/:partId`
@@ -38,19 +48,19 @@ Information about the part.
 *Example:*
 
 	http://goapi.curtmfg.com/part/110003?key=[public api key]
-	
-	
+
+
 ####Parameters
 
 
-| Paramter  |  Description | 
+| Paramter  |  Description |
 |---|---|
 | key **(required)** | Provide your API key  |
 | brand **(required)** | Brand querying that part number for (1=CURT, 3=ARIES, 4=Luverne) |
 
 
 
-####Response 
+####Response
 
 | Property Name  |  Value |  Description |
 |---|---|---|
@@ -99,22 +109,22 @@ curl --request POST \
   --url 'https://goapi.curtmfg.com/part/multi?brandID=3&key=[public api key]' \
   --header 'content-type: application/json' \
   --data '["1042","35-3014"]'
-```	
-	
+```
+
 ####Parameters
 
 
-| Paramter  |  Description | 
+| Paramter  |  Description |
 |---|---|
 | key **(required)** | Provide your API key  |
 | brandID **(required)** | Brand querying part numbers for (1=CURT, 3=ARIES, 4=Luverne) |
 
-####Request Body 
-| Paramter  | value | Description | 
+####Request Body
+| Paramter  | value | Description |
 |---|---|---|
 | [] | []string |An array of strings with product numbers (SKUs)  |
 
-####Response 
+####Response
 Returns an unnamed array of part objets. A part object is described in the Get Single Part response.
 
 | Property Name  |  Value |  Description |
@@ -128,18 +138,18 @@ Get the last added parts
 *Example:*
 
 	http://goapi.curtmfg.com/part/latest?key=[public api key]&count=20&brand=1
-	
-	
+
+
 ####Parameters
 
 
-| Paramter  |  Description | 
+| Paramter  |  Description |
 |---|---|
 | key **(required)** | Provide your API key  |
 | brand *(optional)* | Brand querying part numbers for (1=CURT, 3=ARIES, 4=Luverne) |
 | count *(optional)* | The number of parts you want returned |
 
-####Response 
+####Response
 Returns an unnamed array of part objets. A part object is described in the Get Single Part response.
 
 | Property Name  |  Value |  Description |
@@ -152,7 +162,7 @@ A list of Product Object definitions
 
 #### <a name="aces-vehicle"></a> aces_vehicle ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | [base]()  | object  | Base model of a Vehicle |
 | submodel  | string  | Vehicle submodel |
@@ -160,7 +170,7 @@ A list of Product Object definitions
 
 #### <a name="content"></a> content ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | text  | string  | Content string |
 | [contentType](#contentType)  | object  | ContentType object that describes the content |
@@ -168,7 +178,7 @@ A list of Product Object definitions
 
 #### <a name="contentType"></a> contentType ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | id  | string  | Internal Id |
 | type  | string  | Describes what the conten is i.e. "Description", "Bullet, "Content Brief" |
@@ -176,7 +186,7 @@ A list of Product Object definitions
 
 #### <a name="image"></a> image ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | id *(optional)* 	| int  | Internal Id |
 | size *(optional)*	| string | Describes what the conten is i.e. "Description", "Bullet, "Content Brief" |
@@ -188,7 +198,7 @@ A list of Product Object definitions
 
 #### <a name="price"></a> price ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | id *(optional)* | int  | Internal Id |
 | partId *(optional)* | int  | Part Id reference |
@@ -199,7 +209,7 @@ A list of Product Object definitions
 
 #### <a name="reviews"></a> reviews ####
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | rating  | int  | Star Rating Value (1-5) |
 | subject  | string  | Subject of review |
@@ -213,7 +223,7 @@ A list of Product Object definitions
 #### <a name="video"></a> video ####
 A reresentation of a video. It contains information about the video itself, as well as any associated files.
 
-| Property Name  | Value | Description | 
+| Property Name  | Value | Description |
 |---|---|---|
 | id *(optional)* 		| int  | Internal Id |
 | title *(optional)* 	| string  | Video Title |
@@ -230,4 +240,3 @@ A reresentation of a video. It contains information about the video itself, as w
 | partIds *(optional)* 		| []int  | Related part numbers |
 | websiteId *(optional)* 	| int  | ??? |
 | brands *(optional)* 		| object  | Brand this video was created for |
-

--- a/models/products/part.go
+++ b/models/products/part.go
@@ -215,23 +215,54 @@ func Identifiers(brand int, dtx *apicontext.DataContext) ([]string, error) {
 	return parts, nil
 }
 
-func All(page, count int, dtx *apicontext.DataContext) ([]Part, int, error) {
-	var parts []Part
+func All(page, count int, dtx *apicontext.DataContext, from string, to string) ([]Part, int, error) {
 	var total int
+	var query bson.M
 	brands := getBrandsFromDTX(dtx)
+	parts := make([]Part, 0)
 
 	session, err := mgo.DialWithInfo(database.MongoPartConnectionString())
 	if err != nil {
 		return parts, total, err
 	}
 	defer session.Close()
-	total, err = session.DB(database.ProductDatabase).C(database.ProductCollectionName).Find(bson.M{"brand.id": bson.M{"$in": brands}}).Count()
+
+	if from != "" || to != "" {
+		//In the case that "from" is specified
+		if from != "" {
+			fromTime, err := time.Parse("2006-01-02", from)
+			if err != nil {
+				return parts, total, err
+			}
+			//In the case both "to" and "from" are specified
+			if to != "" {
+				toTime, err := time.Parse("2006-01-02", to)
+				if err != nil {
+					return parts, total, err
+				}
+				query = bson.M{"brand.id": bson.M{"$in": brands}, "date_modified": bson.M{"$lte": toTime, "$gte": fromTime}}
+			} else { //In the case only "from" is specified
+				query = bson.M{"brand.id": bson.M{"$in": brands}, "date_modified": bson.M{"$gte": fromTime}}
+			}
+		} else if to != "" { //In the case only "to" is specified
+			toTime, err := time.Parse("2006-01-02", to)
+			if err != nil {
+				return parts, total, err
+			}
+			query = bson.M{"brand.id": bson.M{"$in": brands}, "date_modified": bson.M{"$lte": toTime}}
+		}
+
+	} else { //In the case neither "to" or "from" are specified
+		query = bson.M{"brand.id": bson.M{"$in": brands}}
+	}
+	total, err = session.DB(database.ProductDatabase).C(database.ProductCollectionName).Find(query).Count()
 	if err != nil {
 		return parts, total, err
 	}
-	//A Mongo index is needed to ensure that the sort doesn't consumer too much memory
+
+	//A Mongo index is needed to ensure that the sort doesn't consume too much memory
 	//See INDEX.md in root directory
-	err = session.DB(database.ProductDatabase).C(database.ProductCollectionName).Find(bson.M{"brand.id": bson.M{"$in": brands}}).Sort("id").Skip(page * count).Limit(count).All(&parts)
+	err = session.DB(database.ProductDatabase).C(database.ProductCollectionName).Find(query).Sort("id").Skip(page * count).Limit(count).All(&parts)
 	return parts, total, err
 }
 

--- a/models/products/part_test.go
+++ b/models/products/part_test.go
@@ -21,7 +21,7 @@ func TestPart(t *testing.T) {
 	})
 
 	Convey("Testing All", t, func() {
-		parts, err := All(0, 1, MockedDTX)
+		parts, err := All(0, 1, MockedDTX, "", "")
 		So(err, ShouldBeNil)
 		So(len(parts), ShouldEqual, 1)
 		So(parts, ShouldHaveSameTypeAs, []Part{})


### PR DESCRIPTION
Adding 'modified-from' and 'modified-to' parameters and associated functionality

Instead of returning 'null', return an empty array when there are no results from the query

Updating documentation for 'format' and 'modified' end-points