### PR TITLE
updated redis address

### DIFF
--- a/helpers/redis/redis.go
+++ b/helpers/redis/redis.go
@@ -24,7 +24,7 @@ func RedisPool(master bool) *redix.Pool {
 	if master && os.Getenv("REDIS_MASTER_ADDRESS") != "" {
 		addr = os.Getenv("REDIS_MASTER_ADDRESS")
 	} else if os.Getenv("REDIS_MASTER_ADDRESS") != "" {
-		addr = os.Getenv("REDIS_SLAVE_ADDRESS")
+		addr = os.Getenv("REDIS_CLIENT_ADDRESS")
 	}
 
 	if master && os.Getenv("REDIS_MASTER_SERVICE_HOST") != "" {

--- a/helpers/redis/redis.go
+++ b/helpers/redis/redis.go
@@ -32,6 +32,10 @@ func RedisPool(master bool) *redix.Pool {
 	} else if os.Getenv("REDIS_SLAVE_SERVICE_HOST") != "" {
 		addr = fmt.Sprintf("%s", os.Getenv("REDIS_SLAVE_SERVICE_HOST"))
 	}
+	addrSplit := strings.Split(addr, ":")
+	if len(addrSplit) == 1 { // no port specified (you would expect more than one item in the string array)
+		addr = addr + ":6379" // if no port, choose default port
+	}
 	return &redix.Pool{
 		MaxIdle:     2,
 		IdleTimeout: 240 * time.Second,


### PR DESCRIPTION
If you take a look at the manifest file, the env variable for gets is REDIS_CLIENT_ADDRESS and yet the code says REDIS_SLAVE_ADDRESS. Every other application is redis client, so updating code for consistency. This also fixes goapi not being able to read from Redis, currently it does not because it sees a blank address for redis.