### PR TITLE
Aries Lookup fix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,10 @@ machine:
     PROD_IMAGE: gcr.io/curt-services/goapi
     STAGE_IMAGE: gcr.io/unicorn-attack/goapi
     PROD_PROJECT_NAME: curt-services
-    PROD_CLUSTER_NAME: api-services
+    PROD_CLUSTER_NAME: goapi
     PROD_ZONE: us-central1-a
     STAGE_PROJECT_NAME: unicorn-attack
-    STAGE_CLUSTER_NAME: staging-1
+    STAGE_CLUSTER_NAME: goapi-staging
     STAGE_ZONE: us-central1-f
   services:
     - docker

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     PROD_ZONE: us-central1-a
     STAGE_PROJECT_NAME: unicorn-attack
     STAGE_CLUSTER_NAME: goapi-staging
-    STAGE_ZONE: us-central1-f
+    STAGE_ZONE: us-central1-a
   services:
     - docker
 

--- a/models/products/category_styles.go
+++ b/models/products/category_styles.go
@@ -185,7 +185,7 @@ func getMakes(ctx *LookupContext, year string) ([]string, error) {
 			"$in": ctx.Brands,
 		},
 	}
-	err := c.Find(qry).Select(bson.M{"vehicle_applications.make": 1, "_id": 0}).All(&apps)
+	err := c.Find(qry).Select(bson.M{"vehicle_applications.make": 1, "vehicle_applications.year": 1, "_id": 0}).All(&apps)
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +197,10 @@ func getMakes(ctx *LookupContext, year string) ([]string, error) {
 		for _, a := range app.Apps {
 			// a.Make = strings.Title(a.Make)
 			if _, ok := existing[strings.ToLower(a.Make)]; !ok {
-				makes = append(makes, strings.Title(a.Make))
-				existing[strings.ToLower(a.Make)] = strings.Title(a.Make)
+				if a.Year == year {
+					makes = append(makes, strings.Title(a.Make))
+					existing[strings.ToLower(a.Make)] = strings.Title(a.Make)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The same thing that was happening to Luverne was happening to Aries. None of the makes were being filtered by year. The impact was smaller, but still there. This should fix this issue

Also updated the zones and clusters for prod and staging.