### PR TITLE
Parts Not Showing Up

### DIFF
--- a/models/products/curtLookup.go
+++ b/models/products/curtLookup.go
@@ -319,7 +319,6 @@ func (c *CurtLookup) GetModels(heavyduty bool) error {
 }
 
 func (c *CurtLookup) GetStyles(heavyduty bool) error {
-
 	err := database.Init()
 	if err != nil {
 		return err
@@ -413,6 +412,7 @@ func (c *CurtLookup) GetParts(dtx *apicontext.DataContext, heavyduty bool) error
 			},
 			"model": bson.RegEx{
 				Pattern: "^" + c.Model + "$",
+				Options: "i",
 			},
 		},
 	}
@@ -427,9 +427,11 @@ func (c *CurtLookup) GetParts(dtx *apicontext.DataContext, heavyduty bool) error
 				},
 				"model": bson.RegEx{
 					Pattern: "^" + c.Model + "$",
+					Options: "i",
 				},
 				"style": bson.RegEx{
 					Pattern: "^" + c.Style + "$",
+					Options: "i",
 				},
 			},
 		}


### PR DESCRIPTION
There are certain makes and models on the curtmfg.com website that would not ever yield any parts when searched. This was simply because of a case sensitivity issue. 

"F-250 **Or** F-350 Super Duty" was actually "F-250 **or** F-350 Super Duty"
"328d XDrive" was actually "328d xDrive"

This has been fixed so that it's case insensitive now.