### PR TITLE
etailer caching incorrect

### DIFF
--- a/models/customer/customer.go
+++ b/models/customer/customer.go
@@ -965,7 +965,7 @@ func GetEtailers(dtx *apicontext.DataContext, count int, page int) (EtailerRespo
 	var dealers []Customer
 	var etailResp EtailerResponse
 	if err == nil && len(data) > 0 {
-		err = json.Unmarshal(data, &dealers)
+		err = json.Unmarshal(data, &etailResp)
 		if err != nil {
 			return etailResp, err
 		}
@@ -1000,9 +1000,8 @@ func GetEtailers(dtx *apicontext.DataContext, count int, page int) (EtailerRespo
 			dealers = append(dealers, cust)
 		}
 	}
-	redis.Setex(redis_key, dealers, 86400)
-
 	etailResp = EtailerResponse{Items: dealers, Total: total}
+	redis.Setex(redis_key, etailResp, 86400)
 
 	return etailResp, err
 }

--- a/models/customer/customer.go
+++ b/models/customer/customer.go
@@ -960,7 +960,7 @@ func GetCustomerCartReference(api_key string, part_id int) (ref int, err error) 
 }
 
 func GetEtailers(dtx *apicontext.DataContext, count int, page int) (EtailerResponse, error) {
-	redis_key := "dealers:etailer:" + dtx.BrandString
+	redis_key := "dealers:etailer:" + dtx.BrandString + ":" + count + ":" + page
 	data, err := redis.Get(redis_key)
 	var dealers []Customer
 	var etailResp EtailerResponse

--- a/models/customer/customer.go
+++ b/models/customer/customer.go
@@ -960,7 +960,7 @@ func GetCustomerCartReference(api_key string, part_id int) (ref int, err error) 
 }
 
 func GetEtailers(dtx *apicontext.DataContext, count int, page int) (EtailerResponse, error) {
-	redis_key := "dealers:etailer:" + dtx.BrandString + ":" + count + ":" + page
+	redis_key := "dealers:etailer:" + dtx.BrandString + ":" + strconv.Itoa(count) + ":" + strconv.Itoa(page)
 	data, err := redis.Get(redis_key)
 	var dealers []Customer
 	var etailResp EtailerResponse


### PR DESCRIPTION
Perficient ran into a problem recent where the etailer resource was returning `null`. This was due to the cache being read incorrectly, and the return value erroring out. This is fixed now.