### PR TITLE
SEC-9 - removing internal key, unmarshalling password

### DIFF
--- a/index.go
+++ b/index.go
@@ -222,8 +222,8 @@ func main() {
 
 	//No lockdown of customer related endpoints for now
 	m.Group("/customer", func(r martini.Router) {
-		r.Get("", middleware.InternalKeyAuthentication, customer_ctlr.GetCustomer)
-		r.Post("", middleware.InternalKeyAuthentication, customer_ctlr.GetCustomer)
+		r.Get("", customer_ctlr.GetCustomer)
+		r.Post("", customer_ctlr.GetCustomer)
 
 		r.Post("/auth", customer_ctlr.AuthenticateUser)
 		r.Get("/auth", customer_ctlr.KeyedUserAuthentication)

--- a/models/customer/user.go
+++ b/models/customer/user.go
@@ -78,7 +78,7 @@ type Warehouse struct {
 
 type ComnetCredential struct {
 	Username string `json:"username" xml:"username"`
-	Password string `json:"password" xml:"password"`
+	Password string `json:"-" xml:"-"`
 }
 
 type ApiCredentials struct {


### PR DESCRIPTION
We're removing the internal key auth, but we're also removing the password from the response