### PR TITLE
Skip bad data

### DIFF
--- a/models/customer/customer.go
+++ b/models/customer/customer.go
@@ -1046,7 +1046,13 @@ func GetLocalDealers(latlng string, distance int, skip int, count int, brandID i
 		}
 
 		if err != nil {
-			return dealerResp, err
+			//skip it. We have some bad data that causes syntax errors
+			//due to the whole isDummy thing, we have fake/unfinished customers
+			//that are causing this issue. Basically by doing this we're just
+			//going to not include them in the where to buy list if they have
+			//data so bad that it can't be rendered
+			//return dealerResp, err
+			continue
 		}
 
 		dealers = append(dealers, *l)


### PR DESCRIPTION
You guys can tell me what you think of this. I don't know another solution other than going through all of our where to buy data and trying to manually fix it. We had a CustomerLocation for example that didn't seem to match up to any real life customer, and it had a stateID of 0, for example. This popped up multiple times and caused the call to fail.

I think just skipping over the bad data is the best solution. 